### PR TITLE
Bugfix - don't add 0.0 cells back to global memory.

### DIFF
--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -230,7 +230,9 @@ void addLocalToGlobal (const amrex::Box& bx,
         i += lo.x;
         j += lo.y;
         k += lo.z;
-        amrex::Gpu::Atomic::AddNoRet( &global(i, j, k), local(i, j, k));
+        if (local(i, j, k) > 0.0_rt) {
+            amrex::Gpu::Atomic::AddNoRet( &global(i, j, k), local(i, j, k));
+        }
     }
 }
 #endif


### PR DESCRIPTION
The way we are doing this, some of these cells may be out of bounds in the global array. Also, I believe it faster to save the bandwidth.